### PR TITLE
Fix overlay display in Streamlit image

### DIFF
--- a/app.py
+++ b/app.py
@@ -79,7 +79,14 @@ if vol is not None:
     mask = img > thr
     overlay = np.zeros((*img.shape, 3), dtype=np.uint8)
     overlay[mask] = [255, 0, 0]
-    st.image(np.concatenate([disp[..., None]]*3, axis=-1) * 0.7 + overlay * 0.3, width=400)
+    composite = (
+        np.clip(
+            np.concatenate([disp[..., None]] * 3, axis=-1) * 0.7 + overlay * 0.3,
+            0,
+            255,
+        ).astype(np.uint8)
+    )
+    st.image(composite, channels="RGB", width=400)
 
     # --- STL Generación y visualización 3D ---
     st.header("Vista 3D y edición STL")


### PR DESCRIPTION
## Summary
- handle overlay blending correctly in Streamlit image display

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848b31375d48329a1e32885beb6c5f5