### PR TITLE
Fix STL generation rerun

### DIFF
--- a/app.py
+++ b/app.py
@@ -91,11 +91,17 @@ if vol is not None:
     # --- STL Generación y visualización 3D ---
     st.header("Vista 3D y edición STL")
     gen_stl = st.button("Generar STL")
-    if gen_stl or "mesh" in st.session_state:
-        mask3d = (vol > thr).astype(np.uint8)
-        verts, faces, _, _ = marching_cubes(mask3d, level=0)
-        mesh = trimesh.Trimesh(vertices=verts, faces=faces)
-        st.session_state.mesh = mesh
+    if gen_stl:
+        with st.spinner("Generando STL..."):
+            mask3d = (vol > thr).astype(np.uint8)
+            verts, faces, _, _ = marching_cubes(mask3d, level=0)
+            mesh = trimesh.Trimesh(vertices=verts, faces=faces)
+            st.session_state.mesh = mesh
+        st.success("STL generado.")
+
+    if "mesh" in st.session_state:
+        mesh = st.session_state.mesh
+        verts, faces = mesh.vertices, mesh.faces
 
         # Visualización 3D (pyvista+plotly)
         cloud = pv.PolyData(verts)


### PR DESCRIPTION
## Summary
- generate STL only when the button is clicked
- show a spinner while the STL is generated
- keep the mesh in session state for later viewing/editing

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848b4f8153483298136ea108f788f07