### PR TITLE
Fix clipping and enable interactive 3D mesh

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,11 +2,6 @@ numpy
 pydicom
 nibabel
 scikit-image
-vtk
-matplotlib
 plotly
 streamlit
-pyvista
-pyvista-xarray
 trimesh
-xvfbwrapper


### PR DESCRIPTION
## Summary
- fix NumPy 2.0 deprecation on plane clipping
- switch STL preview to interactive Plotly viewer
- drop unused headless/PyVista code
- simplify requirements

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6848ce3387b4832983c7e32e4105fbc6