### PR TITLE
Fix 3D layout controls on the left

### DIFF
--- a/app.py
+++ b/app.py
@@ -145,14 +145,10 @@ if 'volume' in st.session_state:
     # --- 3D Preview y flujo pseudo-interactivo ---
     with tab3d:
         st.header("Vista 3D y Edición STL")
-        col_ctrl, col_view = st.columns([1, 2])
+        col_view, col_ctrl = st.columns([2, 1])
         with col_ctrl:
             st.subheader("Controles 3D")
-            drag_mode = st.selectbox(
-                "Modo de interacción",
-                ["orbit", "turntable", "pan"],
-                format_func=lambda m: m.capitalize(),
-            )
+            drag_mode = "orbit"
             step = st.slider(
                 "Resolución mesh (step size)", 1, 5, 1,
                 help="Valores mayores generan mallas más ligeras"

--- a/app.py
+++ b/app.py
@@ -145,82 +145,80 @@ if 'volume' in st.session_state:
     # --- 3D Preview y flujo pseudo-interactivo ---
     with tab3d:
         st.header("Vista 3D y Edición STL")
-        with st.expander("Opciones de 3D / STL"):
+        col_ctrl, col_view = st.columns([1, 2])
+        with col_ctrl:
+            st.subheader("Controles 3D")
             drag_mode = st.selectbox(
                 "Modo de interacción",
                 ["orbit", "turntable", "pan"],
                 format_func=lambda m: m.capitalize(),
             )
-            col1, col2 = st.columns(2)
-            with col1:
-                step = st.slider(
-                    "Resolución mesh (step size)", 1, 5, 1,
-                    help="Valores mayores generan mallas más ligeras"
+            step = st.slider(
+                "Resolución mesh (step size)", 1, 5, 1,
+                help="Valores mayores generan mallas más ligeras"
+            )
+            if st.button("Generar/Actualizar STL"):
+                progress = st.progress(0)
+                with st.spinner("Calculando superficie..."):
+                    mask3d = vol > thr
+                    bbox = bounding_box(mask3d)
+                    mask_crop = mask3d[bbox]
+                    progress.progress(25)
+                    verts, faces, _, _ = marching_cubes(mask_crop.astype(np.uint8), level=0, step_size=step)
+                    offset = np.array([bbox[0].start, bbox[1].start, bbox[2].start])
+                    verts += offset
+                    progress.progress(75)
+                    mesh = trimesh.Trimesh(vertices=verts, faces=faces)
+                    st.session_state['mesh'] = mesh
+                    st.session_state['verts'] = verts
+                    st.session_state['faces'] = faces
+                    st.session_state.pop('clipped_mesh', None)
+                    progress.progress(100)
+                st.success("STL generado.")
+            if 'mesh' in st.session_state:
+                plane_axis = st.selectbox("Eje plano de corte", ["X", "Y", "Z"], key="plane_axis")
+                plane_pos = st.slider("Posición del plano (%)", 0, 100, 50, key="plane_pos")
+                plane_dir = st.selectbox(
+                    "Dirección del corte",
+                    ["Desde mínimo", "Desde máximo"],
+                    key="plane_dir",
                 )
-                if st.button("Generar/Actualizar STL"):
-                    progress = st.progress(0)
-                    with st.spinner("Calculando superficie..."):
-                        # mask3d = (vol > thr).astype(np.uint8)
-                        mask3d = vol > thr
-                        bbox = bounding_box(mask3d)
-                        mask_crop = mask3d[bbox] 
-                        progress.progress(25)
-                        # verts, faces, _, _ = marching_cubes(mask3d, level=0, step_size=step)
-                        verts, faces, _, _ = marching_cubes(mask_crop.astype(np.uint8), level=0, step_size=step)
-                        offset = np.array([bbox[0].start, bbox[1].start, bbox[2].start])
-                        verts += offset
-                        progress.progress(75)
-                        mesh = trimesh.Trimesh(vertices=verts, faces=faces)
-                        st.session_state['mesh'] = mesh
-                        st.session_state['verts'] = verts
-                        st.session_state['faces'] = faces
-                        st.session_state.pop('clipped_mesh', None)
-                        progress.progress(100)
-                    st.success("STL generado.")
-            with col2:
-                if 'mesh' in st.session_state:
-                    plane_axis = st.selectbox("Eje plano de corte", ["X", "Y", "Z"], key="plane_axis")
-                    plane_pos = st.slider("Posición del plano (%)", 0, 100, 50, key="plane_pos")
-                    plane_dir = st.selectbox(
-                        "Dirección del corte",
-                        ["Desde mínimo", "Desde máximo"],
-                        key="plane_dir",
-                    )
-                    if st.button("Aplicar recorte plano"):
-                        verts = st.session_state['verts']
-                        faces = st.session_state['faces']
-                        axis_num = {"X":0,"Y":1,"Z":2}[plane_axis]
-                        axis_vals = verts[:, axis_num]
-                        if plane_dir == "Desde mínimo":
-                            plane_val = axis_vals.min() + np.ptp(axis_vals) * plane_pos / 100
-                            faces_keep = np.all(verts[faces][:, :, axis_num] >= plane_val, axis=1)
-                        else:
-                            plane_val = axis_vals.max() - np.ptp(axis_vals) * plane_pos / 100
-                            faces_keep = np.all(verts[faces][:, :, axis_num] <= plane_val, axis=1)
-                        faces_clip = faces[faces_keep]
-                        mesh_clip = trimesh.Trimesh(vertices=verts, faces=faces_clip)
-                        st.session_state['clipped_mesh'] = mesh_clip
-                        st.success("Recorte aplicado.")
+                if st.button("Aplicar recorte plano"):
+                    verts = st.session_state['verts']
+                    faces = st.session_state['faces']
+                    axis_num = {"X": 0, "Y": 1, "Z": 2}[plane_axis]
+                    axis_vals = verts[:, axis_num]
+                    if plane_dir == "Desde mínimo":
+                        plane_val = axis_vals.min() + np.ptp(axis_vals) * plane_pos / 100
+                        faces_keep = np.all(verts[faces][:, :, axis_num] >= plane_val, axis=1)
+                    else:
+                        plane_val = axis_vals.max() - np.ptp(axis_vals) * plane_pos / 100
+                        faces_keep = np.all(verts[faces][:, :, axis_num] <= plane_val, axis=1)
+                    faces_clip = faces[faces_keep]
+                    mesh_clip = trimesh.Trimesh(vertices=verts, faces=faces_clip)
+                    st.session_state['clipped_mesh'] = mesh_clip
+                    st.success("Recorte aplicado.")
+        with col_view:
 
-        # --- Render 3D preview ---
-        preview_mesh = None
-        if 'clipped_mesh' in st.session_state:
-            preview_mesh = st.session_state['clipped_mesh']
-        elif 'mesh' in st.session_state:
-            preview_mesh = st.session_state['mesh']
+            # --- Render 3D preview ---
+            preview_mesh = None
+            if 'clipped_mesh' in st.session_state:
+                preview_mesh = st.session_state['clipped_mesh']
+            elif 'mesh' in st.session_state:
+                preview_mesh = st.session_state['mesh']
 
-        if preview_mesh:
-            verts = preview_mesh.vertices
-            faces = preview_mesh.faces
-            if len(verts) > 0 and len(faces) > 0:
-                x, y, z = verts.T
-                if faces.ndim > 2:
-                    faces_tri = faces.reshape(-1, 3)
-                else:
-                    faces_tri = faces
-                i, j, k = faces_tri.T
-                mesh3d = go.Mesh3d(x=x, y=y, z=z, i=i, j=j, k=k, color="lightgray", opacity=1.0)
-                fig = go.Figure(data=[mesh3d])
+            if preview_mesh:
+                verts = preview_mesh.vertices
+                faces = preview_mesh.faces
+                if len(verts) > 0 and len(faces) > 0:
+                    x, y, z = verts.T
+                    if faces.ndim > 2:
+                        faces_tri = faces.reshape(-1, 3)
+                    else:
+                        faces_tri = faces
+                    i, j, k = faces_tri.T
+                    mesh3d = go.Mesh3d(x=x, y=y, z=z, i=i, j=j, k=k, color="lightgray", opacity=1.0)
+                    fig = go.Figure(data=[mesh3d])
 
                 # Preview plane position if controls exist
                 if 'plane_axis' in st.session_state and 'plane_pos' in st.session_state:


### PR DESCRIPTION
## Summary
- organize the 3D viewer tab in two columns
- put all 3D controls on the left and the viewer on the right

## Testing
- `python -m py_compile app.py`

------
https://chatgpt.com/codex/tasks/task_e_684903b4007083298435557ce51534bd