### PR TITLE
Adjust personalized threshold slider range

### DIFF
--- a/app.py
+++ b/app.py
@@ -131,7 +131,7 @@ if 'volume' in st.session_state:
 
     if thr_option == "Personalizado":
         thr_min, thr_max = sidebar.slider(
-            "Rango de umbral", int(vmin), int(vmax), (int(vmin), int(vmax))
+            "Rango de umbral", -3000, 3000, (int(vmin), int(vmax))
         )
     else:
         thr_min, thr_max = preset_ranges[thr_option]


### PR DESCRIPTION
## Summary
- expand the custom threshold slider range to [-3000, 3000]

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a5c93163c8329af3e90bc29a4cb3e