### PR TITLE
Enable optional GPU processing with CuPy

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Este proyecto ofrece un visor de volúmenes DICOM y NIfTI construido con **Strea
 pip install -r requirements.txt
 ```
 
+Si cuentas con una GPU compatible, las bibliotecas `cupy` y `cucim` se
+aprovecharán automáticamente para acelerar el procesamiento.
+
 ### Ejecuta la aplicación
 
 ```bash

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,5 @@ plotly
 streamlit
 trimesh
 scipy
+cupy
+cucim


### PR DESCRIPTION
## Summary
- add `cupy` and `cucim` to requirements
- use GPU libraries when available and fall back to CPU
- convert arrays to CPU when sending to Streamlit/Plotly
- mention GPU acceleration in README

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_684a7415940883299595bbe96a76c916